### PR TITLE
cloudfront_origin_pathをlocalからvariableに

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,6 +1,5 @@
 locals {
-  cloudfront_origin_path = "/${terraform.workspace}"
-  s3_origin_id = "${var.s3_bucket_name}${local.cloudfront_origin_path}"
+  s3_origin_id = "${var.s3_bucket_name}${var.cloudfront_origin_path}"
 }
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
@@ -18,7 +17,7 @@ resource "aws_cloudfront_distribution" "web_dist" {
   origin {
     domain_name = aws_s3_bucket.hosting.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
-    origin_path = local.cloudfront_origin_path
+    origin_path = var.cloudfront_origin_path
 
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,7 @@ variable "route53_zone_id" {
 variable "s3_bucket_name" {
   description = "S3 bucket name"
 }
+variable "cloudfront_origin_path" {
+  default = "/"
+  description = "Origin path of CloudFront"
+}


### PR DESCRIPTION
cloudfront_origin_path を変数で指定できるようにした。default 値を `"/${terraform.workspace}"` ではなく `"/"` とした (なぜなら variablesの中で変数が使えないから) ので、今のバージョンと互換性がないので、これをマージしたらメジャーバージョンをあげたリリースにする