### PR TITLE
Enable to allow CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provision a static website hosted through S3 + CloudFront in AWS
 ```hcl
 module "website" {
   source = "realglobe-Inc/static-website/aws"
-  version = "2.1.1"
+  version = "2.2.0"
   service_name = "your-service-name"
   aws_profile = "aws-profile-name"
   domain_names = list("foo.example.com", "bar.example.com")

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -43,13 +43,14 @@ resource "aws_cloudfront_distribution" "web_dist" {
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.s3_origin_id
     compress         = true
 
     forwarded_values {
       query_string = false
+      headers = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]
 
       cookies {
         forward = "none"

--- a/s3.tf
+++ b/s3.tf
@@ -20,6 +20,13 @@ resource "aws_s3_bucket" "hosting" {
   bucket = var.s3_bucket_name
   policy = data.aws_iam_policy_document.bucket_policy.json
 
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = var.cors_allowed_origins
+    max_age_seconds = 3000
+  }
+
   versioning {
     enabled = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,8 @@ variable "lambda_function_associations" {
   type = map(string)
   default = {}
 }
+variable "cors_allowed_origins" {
+  description = "CORS allowed origins"
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
+ S3 の CORS 設定で許可する origin を指定できるようにした
+ たとえば変数`cors_allowed_origins = ["*"]` にするとどこからでもアクセスできる
